### PR TITLE
Implement wallet recovery

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -2,7 +2,7 @@ EXPO_PUBLIC_API_URL='http://<your_local_ip>:8080/api/v1'
 EXPO_PUBLIC_SENTRY_DSN='your_sentry_dsn'
 SENTRY_AUTH_TOKEN=your_sentry_auth_token
 
-#Account Recovery Staging
+#Account Recovery
 EXPO_PUBLIC_ACCOUNT_RECOVERY_PLANET_PAY_NODE=
 EXPO_PUBLIC_ACCOUNT_RECOVERY_BIGGER_NODE=
 

--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,10 @@
 EXPO_PUBLIC_API_URL='http://<your_local_ip>:8080/api/v1'
 EXPO_PUBLIC_SENTRY_DSN='your_sentry_dsn'
 SENTRY_AUTH_TOKEN=your_sentry_auth_token
+
+#Account Recovery Staging
+EXPO_PUBLIC_ACCOUNT_RECOVERY_PLANET_PAY_NODE=
+EXPO_PUBLIC_ACCOUNT_RECOVERY_BIGGER_NODE=
+
+#Stellar
+EXPO_PUBLIC_STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"

--- a/__mocks__/@react-native-async-storage/async-storage.js
+++ b/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,0 +1,1 @@
+export * from '@react-native-async-storage/async-storage/jest/async-storage-mock';

--- a/src/app/(auth)/_layout.tsx
+++ b/src/app/(auth)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack, router } from 'expo-router';
 
 import { BackButton } from '@/components/BackButton/BackButton';
+import { GoToBackButtonType } from '@/types/enum/go-to-back-button-type.enum';
 
 export default function AuthLayout() {
 	return (
@@ -8,11 +9,10 @@ export default function AuthLayout() {
 			screenOptions={{
 				headerTransparent: true,
 				headerTitleStyle: { color: 'transparent' },
-				headerTitle: '',
-				headerBackTitle: '',
-				headerBackVisible: false,
 				headerLeft: () =>
-					router.canGoBack() && <BackButton returnType={'back'} />,
+					router.canGoBack() && (
+						<BackButton returnType={GoToBackButtonType.BACK} />
+					),
 			}}
 		>
 			<Stack.Screen name="login" />

--- a/src/app/(recovery)/_layout.tsx
+++ b/src/app/(recovery)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack, router } from 'expo-router';
 
 import { BackButton } from '@/components/BackButton/BackButton';
+import { GoToBackButtonType } from '@/types/enum/go-to-back-button-type.enum';
 
 export default function RecoveryLayout() {
 	return (
@@ -8,11 +9,10 @@ export default function RecoveryLayout() {
 			screenOptions={{
 				headerTransparent: true,
 				headerTitleStyle: { color: 'transparent' },
-				headerTitle: '',
-				headerBackTitle: '',
-				headerBackVisible: false,
 				headerLeft: () =>
-					router.canGoBack() && <BackButton returnType={'back'} />,
+					router.canGoBack() && (
+						<BackButton returnType={GoToBackButtonType.BACK} />
+					),
 			}}
 		>
 			<Stack.Screen name="recover-account" />

--- a/src/app/(recovery)/_layout.tsx
+++ b/src/app/(recovery)/_layout.tsx
@@ -1,0 +1,21 @@
+import { Stack, router } from 'expo-router';
+
+import { BackButton } from '@/components/BackButton/BackButton';
+
+export default function RecoveryLayout() {
+	return (
+		<Stack
+			screenOptions={{
+				headerTransparent: true,
+				headerTitleStyle: { color: 'transparent' },
+				headerTitle: '',
+				headerBackTitle: '',
+				headerBackVisible: false,
+				headerLeft: () =>
+					router.canGoBack() && <BackButton returnType={'back'} />,
+			}}
+		>
+			<Stack.Screen name="recover-account" />
+		</Stack>
+	);
+}

--- a/src/app/(recovery)/recover-account.tsx
+++ b/src/app/(recovery)/recover-account.tsx
@@ -1,7 +1,8 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { Text, View } from 'react-native';
-import { formatRecoveryCodesByDomain } from 'utils/formatRecoveryCodesByDomain';
+
+import { formatRecoveryCodesByDomain } from '../../../utils/formatRecoveryCodesByDomain';
 
 import { BackgroundWrapper } from '@/components/BackgroundWrapper/BackgroundWrapper';
 import { CustomModal } from '@/components/CustomModal/CustomModal';

--- a/src/app/(recovery)/recover-account.tsx
+++ b/src/app/(recovery)/recover-account.tsx
@@ -1,0 +1,97 @@
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import { Text, View } from 'react-native';
+
+import { BackgroundWrapper } from '@/components/BackgroundWrapper/BackgroundWrapper';
+import { CustomModal } from '@/components/CustomModal/CustomModal';
+import { CustomInput } from '@/components/Form/CustomInput/CustomInput';
+import { SubmitButton } from '@/components/Form/SubmitButton/SubmitButton';
+import { accountRecoveryDomains } from '@/constants/account-recovery-domains';
+import { RECOVER_ACCOUNT_INDICATIONS } from '@/constants/account-recovery-screen-text.constant';
+import { recoveryAccountInputs } from '@/constants/recover-account-inputs.constants';
+import { RECOVERY_MODAL } from '@/constants/recovery.modal.constant';
+import { useRecoveryApi } from '@/hooks/useRecoveryApi';
+import { IRecoveryCodesFormFields } from '@/interfaces/recovery/request/IRecoveryCodesFormFields.interface';
+import { recoverAccountSchema } from '@/validation/schema/recover-account.schema';
+
+const RecoverAccountScreen = () => {
+	const { submitRecoveryCodes, isLoading } = useRecoveryApi();
+	const defaultValues: IRecoveryCodesFormFields = {
+		planetPayRecoveryCode: '',
+		biggerRecoveryCode: '',
+	};
+	const { control, handleSubmit } = useForm<IRecoveryCodesFormFields>({
+		defaultValues,
+		resolver: yupResolver(recoverAccountSchema),
+	});
+
+	const fromRecoveryCodeToServerDomainKeyValueResponse = (
+		data: IRecoveryCodesFormFields,
+	) => {
+		return {
+			[accountRecoveryDomains.PLANET_PAY]: data.planetPayRecoveryCode,
+			[accountRecoveryDomains.BIGGER]: data.biggerRecoveryCode,
+		};
+	};
+	const onSubmit = async (data: IRecoveryCodesFormFields) => {
+		const recoveryCodes = fromRecoveryCodeToServerDomainKeyValueResponse(data);
+		await submitRecoveryCodes.mutateAsync({ codes: recoveryCodes });
+	};
+
+	return (
+		<BackgroundWrapper>
+			<View
+				testID="recoverAccountScreen"
+				className="flex top-1/4 justify-center items-center bg-white mx-8 pb-4 rounded-lg"
+			>
+				<Text
+					className="text-2xl font-bold pt-4"
+					testID="recoverAccountScreenTitle"
+				>
+					Recover your Account
+				</Text>
+
+				<Text
+					className="text-center text-sm text-gray-500 mt-3 mx-4"
+					testID="recoverAccountIndications"
+				>
+					{RECOVER_ACCOUNT_INDICATIONS}
+				</Text>
+
+				{recoveryAccountInputs.map(
+					({ label, placeholder, name, testID, maxLength }) => (
+						<CustomInput
+							key={name}
+							label={label}
+							placeholder={placeholder}
+							name={name as keyof IRecoveryCodesFormFields}
+							control={control}
+							maxLength={maxLength}
+							testID={testID}
+						/>
+					),
+				)}
+
+				<SubmitButton
+					label="Recover"
+					testID="recoverAccountSubmitButton"
+					onPress={handleSubmit(onSubmit)}
+					isLoading={isLoading}
+				/>
+				<Text className="text-center text-xs text-gray-500 mt-14 mx-4">
+					Powered by PlanetPay & Bigger
+				</Text>
+			</View>
+
+			<CustomModal
+				visible={isLoading}
+				title={RECOVERY_MODAL.TITLE}
+				message={RECOVERY_MODAL.MESSAGE}
+				showLoading={true}
+				testID={RECOVERY_MODAL.TEST_ID}
+			/>
+		</BackgroundWrapper>
+	);
+};
+
+export default RecoverAccountScreen;

--- a/src/app/(recovery)/recover-account.tsx
+++ b/src/app/(recovery)/recover-account.tsx
@@ -1,12 +1,12 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { Text, View } from 'react-native';
+import { formatRecoveryCodesByDomain } from 'utils/formatRecoveryCodesByDomain';
 
 import { BackgroundWrapper } from '@/components/BackgroundWrapper/BackgroundWrapper';
 import { CustomModal } from '@/components/CustomModal/CustomModal';
 import { CustomInput } from '@/components/Form/CustomInput/CustomInput';
 import { SubmitButton } from '@/components/Form/SubmitButton/SubmitButton';
-import { accountRecoveryDomains } from '@/constants/account-recovery-domains';
 import { RECOVER_ACCOUNT_INDICATIONS } from '@/constants/account-recovery-screen-text.constant';
 import { recoveryAccountInputs } from '@/constants/recover-account-inputs.constants';
 import { RECOVERY_MODAL } from '@/constants/recovery.modal.constant';
@@ -25,16 +25,8 @@ const RecoverAccountScreen = () => {
 		resolver: yupResolver(recoverAccountSchema),
 	});
 
-	const fromRecoveryCodeToServerDomainKeyValueResponse = (
-		data: IRecoveryCodesFormFields,
-	) => {
-		return {
-			[accountRecoveryDomains.PLANET_PAY]: data.planetPayRecoveryCode,
-			[accountRecoveryDomains.BIGGER]: data.biggerRecoveryCode,
-		};
-	};
 	const onSubmit = async (data: IRecoveryCodesFormFields) => {
-		const recoveryCodes = fromRecoveryCodeToServerDomainKeyValueResponse(data);
+		const recoveryCodes = formatRecoveryCodesByDomain(data);
 		await submitRecoveryCodes.mutateAsync({ codes: recoveryCodes });
 	};
 
@@ -79,7 +71,7 @@ const RecoverAccountScreen = () => {
 					isLoading={isLoading}
 				/>
 				<Text className="text-center text-xs text-gray-500 mt-14 mx-4">
-					Powered by PlanetPay & Bigger
+					Powered by Planet Pay & Bigger
 				</Text>
 			</View>
 

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/assets/icons';
 import { NavigationRoutes } from '@/constants/navigation.routes.enum';
 import { AuthContext } from '@/context/auth.context';
+import { GoToBackButtonType } from '@/types/enum/go-to-back-button-type.enum';
 
 export default function TabLayout() {
 	const TabsColors = {
@@ -41,7 +42,10 @@ export default function TabLayout() {
 				headerShown: true,
 				headerLeft: () =>
 					router.canGoBack() && (
-						<BackButton className="pl-2" returnType={'dismiss'} />
+						<BackButton
+							className="pl-2"
+							returnType={GoToBackButtonType.DISMISS}
+						/>
 					),
 				tabBarStyle: {
 					backgroundColor: TabsColors.tabBarBackground,

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -69,6 +69,12 @@ function RootLayout() {
 									headerShown: false,
 								}}
 							/>
+							<Stack.Screen
+								name="(recovery)"
+								options={{
+									headerShown: false,
+								}}
+							/>
 						</Stack>
 					</BackgroundWrapper>
 				</AuthProvider>

--- a/src/components/BackButton/BackButton.tsx
+++ b/src/components/BackButton/BackButton.tsx
@@ -1,15 +1,21 @@
 import { router } from 'expo-router';
 import { Text, TouchableOpacity } from 'react-native';
 
+import { GoToBackButtonType } from '@/types/enum/go-to-back-button-type.enum';
+
 interface IBackButtonProps {
-	returnType: 'back' | 'dismiss';
+	returnType: GoToBackButtonType;
 	className?: string;
 }
 
 export const BackButton = ({ returnType, className }: IBackButtonProps) => {
 	return (
 		<TouchableOpacity
-			onPress={() => (returnType === 'back' ? router.back() : router.dismiss())}
+			onPress={() =>
+				returnType === GoToBackButtonType.BACK
+					? router.back()
+					: router.dismiss()
+			}
 			testID="goBackButton"
 		>
 			<Text className={`text-4xl ${className}`}>←</Text>

--- a/src/constants/account-recovery-domains.ts
+++ b/src/constants/account-recovery-domains.ts
@@ -1,0 +1,11 @@
+const TEST_NODE_1 = 'https://local.recovery.io';
+const TEST_NODE_2 = 'https://recovery-local.systems';
+
+export const accountRecoveryDomains = {
+	PLANET_PAY: new URL(
+		process.env.EXPO_PUBLIC_ACCOUNT_RECOVERY_PLANET_PAY_NODE ?? TEST_NODE_1,
+	).host,
+	BIGGER: new URL(
+		process.env.EXPO_PUBLIC_ACCOUNT_RECOVERY_BIGGER_NODE ?? TEST_NODE_2,
+	).host,
+};

--- a/src/constants/account-recovery-screen-text.constant.ts
+++ b/src/constants/account-recovery-screen-text.constant.ts
@@ -1,0 +1,2 @@
+export const RECOVER_ACCOUNT_INDICATIONS =
+	'You will receive two emails with recovery codes. Please enter each code in the input field that corresponds to the sender of the email';

--- a/src/constants/navigation.routes.enum.ts
+++ b/src/constants/navigation.routes.enum.ts
@@ -10,4 +10,5 @@ export enum NavigationRoutes {
 	FORGOT_PASSWORD = '/(auth)/forgot-password',
 	CONFIRM_PASSWORD = '/(auth)/confirm-password',
 	CONFIRM_USER = '/(auth)/confirm-user',
+	RECOVERY = '/(recovery)/recover-account',
 }

--- a/src/constants/recover-account-inputs.constants.ts
+++ b/src/constants/recover-account-inputs.constants.ts
@@ -1,0 +1,16 @@
+export const recoveryAccountInputs = [
+	{
+		label: 'Planet Pay Recovery Code',
+		placeholder: 'Enter your Planet Pay Recovery Code',
+		name: 'planetPayRecoveryCode',
+		testID: 'planetPayRecoveryCodeInput',
+		maxLength: 5,
+	},
+	{
+		label: 'Bigger Recovery Code',
+		placeholder: 'Enter your Bigger Recovery Code',
+		name: 'biggerRecoveryCode',
+		testID: 'biggerRecoveryCodeInput',
+		maxLength: 5,
+	},
+];

--- a/src/constants/recovery.modal.constant.ts
+++ b/src/constants/recovery.modal.constant.ts
@@ -1,0 +1,5 @@
+export const RECOVERY_MODAL = {
+	TITLE: 'Recover Account',
+	MESSAGE: 'Your account is being recovered. Please wait...',
+	TEST_ID: 'recoveryAccountModal',
+};

--- a/src/errors/messages/error.messages.ts
+++ b/src/errors/messages/error.messages.ts
@@ -2,4 +2,15 @@ export const ERROR_MESSAGES = {
 	GETTING_SECRET_KEY: 'Error getting secret key:',
 	STORING_KEYPAIR: 'Error storing keypair',
 	GEN_DEVICE_KEYPAIR: 'Error generating device keypair',
+	GENERATING_RECOVERY_ACCOUNTS:
+		'Error generating recovery accounts. Please try again.',
+	SIGNING_CHALLENGES: 'Error signing challenges:',
+	SUBMITTING_TRANSACTION: 'Error submitting transaction:',
+	GENERATING_RECOVERY_TOKENS: 'Error generating recovery tokens:',
+	CONFIGURING_RECOVERY: 'Error configuring recovery:',
+	SAVING_SIGNER: 'Error saving signers',
+	USER_NOT_FOUND_BEFORE_RECOVERY: 'User not found before recovering account',
+	RECOVERY_CODE_MAX_LENGTH_ERROR_MESSAGE:
+		'Recovery code must be 5 characters long',
+	RECOVERY_CODE_REQUIRED_ERROR_MESSAGE: 'Recovery code is required',
 };

--- a/src/hooks/useRecoveryApi.tsx
+++ b/src/hooks/useRecoveryApi.tsx
@@ -1,0 +1,80 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import { Alert } from 'react-native';
+
+import { storeDeviceSecretKey } from '../../utils/handleDeviceSecretKey';
+import { generateKeypair } from '../../utils/stellar/generateKeypair';
+
+import { NavigationRoutes } from '@/constants/navigation.routes.enum';
+import { useAuthContext } from '@/context/auth.context';
+import { ERROR_MESSAGES } from '@/errors/messages/error.messages';
+import { IBaseApiResponseError } from '@/interfaces/api/IApiResponseError';
+import { IAuthenticateWithVerificationCodeRequest } from '@/interfaces/recovery/request/IAuthenticateWithVerificationCodeRequest.interface';
+import { recoveryService } from '@/services/recovery/recovery.service';
+import { submissionService } from '@/services/submission/submission.service';
+
+export function useRecoveryApi() {
+	const router = useRouter();
+	const [isLoading, setIsLoading] = useState(false);
+	const { user, setIsAuthenticated } = useAuthContext();
+
+	const submitRecoveryCodes = useMutation({
+		mutationFn: async ({ codes }: IAuthenticateWithVerificationCodeRequest) => {
+			setIsLoading(true);
+			return recoveryService.authenticateWithVerificationCode({ codes });
+		},
+		onSuccess: async (response) => {
+			if (!user) {
+				throw new Error(ERROR_MESSAGES.USER_NOT_FOUND_BEFORE_RECOVERY);
+			}
+			const { externalAuthTokens } = response.data.attributes;
+			console.log('externalAuthTokens', externalAuthTokens);
+
+			const newDeviceKey = generateKeypair();
+
+			const {
+				data: {
+					attributes: { xdr },
+				},
+			} = await recoveryService.recoverAccount({
+				newDeviceKey: newDeviceKey.publicKey(),
+			});
+
+			const {
+				data: {
+					attributes: { xdr: transaction },
+				},
+			} = await recoveryService.generateServersSignatures({
+				externalAuthTokens,
+				transaction: xdr,
+			});
+
+			await submissionService.submitXdr(transaction);
+
+			await storeDeviceSecretKey(user.username, newDeviceKey.secret(), false);
+
+			setIsLoading(false);
+			setIsAuthenticated(true);
+			return router.replace(NavigationRoutes.HOME);
+		},
+		onError: (error: IBaseApiResponseError) => {
+			if (error instanceof AxiosError) {
+				Alert.alert(String(error.response?.data.message));
+			} else if (error instanceof Error) {
+				Alert.alert(String(error.message));
+			} else if (error.error.title) {
+				Alert.alert(String(error.error.title));
+			}
+			setIsLoading(false);
+			setIsAuthenticated(false);
+			router.replace(NavigationRoutes.LOGIN);
+		},
+	});
+
+	return {
+		submitRecoveryCodes,
+		isLoading,
+	};
+}

--- a/src/hooks/useRecoveryApi.tsx
+++ b/src/hooks/useRecoveryApi.tsx
@@ -30,7 +30,6 @@ export function useRecoveryApi() {
 				throw new Error(ERROR_MESSAGES.USER_NOT_FOUND_BEFORE_RECOVERY);
 			}
 			const { externalAuthTokens } = response.data.attributes;
-			console.log('externalAuthTokens', externalAuthTokens);
 
 			const newDeviceKey = generateKeypair();
 

--- a/src/interfaces/recovery/IServerDomainKeyValueResponse.interface.ts
+++ b/src/interfaces/recovery/IServerDomainKeyValueResponse.interface.ts
@@ -1,0 +1,3 @@
+export interface IServerDomainKeyValueResponse {
+	[ACCOUNT_RECOVERY_NODE_DOMAIN: string]: string;
+}

--- a/src/interfaces/recovery/request/IAddSignatureRequest.interface.ts
+++ b/src/interfaces/recovery/request/IAddSignatureRequest.interface.ts
@@ -1,0 +1,3 @@
+export interface IAddSignatureRequest {
+	transaction: string;
+}

--- a/src/interfaces/recovery/request/IAuthenticateWithVerificationCodeRequest.interface.ts
+++ b/src/interfaces/recovery/request/IAuthenticateWithVerificationCodeRequest.interface.ts
@@ -1,0 +1,5 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IAuthenticateWithVerificationCodeRequest {
+	codes: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/recovery/request/IConfigureAccountRecoveryRequest.interface.ts
+++ b/src/interfaces/recovery/request/IConfigureAccountRecoveryRequest.interface.ts
@@ -1,0 +1,6 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IConfigureAccountRecoveryRequest {
+	deviceKey: string;
+	tokens: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/recovery/request/ICreateSignerRequest.interface.ts
+++ b/src/interfaces/recovery/request/ICreateSignerRequest.interface.ts
@@ -1,0 +1,5 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface ICreateSignerRequest {
+	signers: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/recovery/request/IGenerateRecoveryTokenRequest.interface.ts
+++ b/src/interfaces/recovery/request/IGenerateRecoveryTokenRequest.interface.ts
@@ -1,0 +1,5 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IGenerateRecoveryTokenRequest {
+	signedChallenges: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/recovery/request/IGenerateServersSignaturesRequest.interface.ts
+++ b/src/interfaces/recovery/request/IGenerateServersSignaturesRequest.interface.ts
@@ -1,0 +1,6 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IGenerateServersSignaturesRequest {
+	externalAuthTokens: IServerDomainKeyValueResponse;
+	transaction: string;
+}

--- a/src/interfaces/recovery/request/IRecoverAccountRequest.interface.ts
+++ b/src/interfaces/recovery/request/IRecoverAccountRequest.interface.ts
@@ -1,0 +1,3 @@
+export interface IRecoverAccountRequest {
+	newDeviceKey: string;
+}

--- a/src/interfaces/recovery/request/IRecoveryCodesFormFields.interface.ts
+++ b/src/interfaces/recovery/request/IRecoveryCodesFormFields.interface.ts
@@ -1,0 +1,4 @@
+export interface IRecoveryCodesFormFields {
+	planetPayRecoveryCode: string;
+	biggerRecoveryCode: string;
+}

--- a/src/interfaces/recovery/response/IConfigureAccountRecoveryResponse.interface.ts
+++ b/src/interfaces/recovery/response/IConfigureAccountRecoveryResponse.interface.ts
@@ -1,0 +1,6 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IConfigureAccountRecoveryResponse {
+	xdr: string;
+	signers: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/recovery/response/IGenerateRecoveryChallengeResponse.interface.ts
+++ b/src/interfaces/recovery/response/IGenerateRecoveryChallengeResponse.interface.ts
@@ -1,0 +1,5 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IGenerateRecoveryChallengeResponse {
+	challenges: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/recovery/response/IGenerateRecoveryTokenResponse.interface.ts
+++ b/src/interfaces/recovery/response/IGenerateRecoveryTokenResponse.interface.ts
@@ -1,0 +1,5 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IGenerateRecoveryTokenResponse {
+	tokens: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/recovery/response/IVerifyExternalAuthCodesResponse.interface.ts
+++ b/src/interfaces/recovery/response/IVerifyExternalAuthCodesResponse.interface.ts
@@ -1,0 +1,5 @@
+import { IServerDomainKeyValueResponse } from '../IServerDomainKeyValueResponse.interface';
+
+export interface IVerifyExternalAuthCodesResponse {
+	externalAuthTokens: IServerDomainKeyValueResponse;
+}

--- a/src/interfaces/services/IRecoveryService.ts
+++ b/src/interfaces/services/IRecoveryService.ts
@@ -1,0 +1,36 @@
+import { IAuthenticateWithVerificationCodeRequest } from '../recovery/request/IAuthenticateWithVerificationCodeRequest.interface';
+import { IConfigureAccountRecoveryRequest } from '../recovery/request/IConfigureAccountRecoveryRequest.interface';
+import { ICreateSignerRequest } from '../recovery/request/ICreateSignerRequest.interface';
+import { IGenerateRecoveryTokenRequest } from '../recovery/request/IGenerateRecoveryTokenRequest.interface';
+import { IGenerateServersSignaturesRequest } from '../recovery/request/IGenerateServersSignaturesRequest.interface';
+import { IRecoverAccountRequest } from '../recovery/request/IRecoverAccountRequest.interface';
+import { IConfigureAccountRecoveryResponse } from '../recovery/response/IConfigureAccountRecoveryResponse.interface';
+import { IGenerateRecoveryChallengeResponse } from '../recovery/response/IGenerateRecoveryChallengeResponse.interface';
+import { IGenerateRecoveryTokenResponse } from '../recovery/response/IGenerateRecoveryTokenResponse.interface';
+import { IVerifyExternalAuthCodesResponse } from '../recovery/response/IVerifyExternalAuthCodesResponse.interface';
+import { IStellarXdrResponse } from '../stellar/IStellarXdrResponse';
+
+import { IBaseApiResponse } from '@/types/api.types';
+
+export interface IRecoveryService {
+	getAuthChallenges: () => Promise<
+		IBaseApiResponse<IGenerateRecoveryChallengeResponse>
+	>;
+	generateRecoveryTokens: (
+		generateRecoveryTokenRequest: IGenerateRecoveryTokenRequest,
+	) => Promise<IBaseApiResponse<IGenerateRecoveryTokenResponse>>;
+	configureRecovery: (
+		configureRecoveryRequest: IConfigureAccountRecoveryRequest,
+	) => Promise<IBaseApiResponse<IConfigureAccountRecoveryResponse>>;
+	saveSigner: (saveSignerRequest: ICreateSignerRequest) => Promise<void>;
+	sendVerificationCodes: () => Promise<void>;
+	authenticateWithVerificationCode: (
+		authenticateWithVerificationCodeRequest: IAuthenticateWithVerificationCodeRequest,
+	) => Promise<IBaseApiResponse<IVerifyExternalAuthCodesResponse>>;
+	recoverAccount: (
+		recoverAccountRequest: IRecoverAccountRequest,
+	) => Promise<IBaseApiResponse<IStellarXdrResponse>>;
+	generateServersSignatures: (
+		generateServersSignaturesRequest: IGenerateServersSignaturesRequest,
+	) => Promise<IBaseApiResponse<IStellarXdrResponse>>;
+}

--- a/src/services/recovery/recovery.service.ts
+++ b/src/services/recovery/recovery.service.ts
@@ -1,0 +1,96 @@
+import { formatTokenHeaders } from '../../../utils/formatTokenHeaders';
+import { ApiRequestConfig, apiService } from '../api.services';
+
+import { IAuthenticateWithVerificationCodeRequest } from '@/interfaces/recovery/request/IAuthenticateWithVerificationCodeRequest.interface';
+import { IConfigureAccountRecoveryRequest } from '@/interfaces/recovery/request/IConfigureAccountRecoveryRequest.interface';
+import { ICreateSignerRequest } from '@/interfaces/recovery/request/ICreateSignerRequest.interface';
+import { IGenerateRecoveryTokenRequest } from '@/interfaces/recovery/request/IGenerateRecoveryTokenRequest.interface';
+import { IGenerateServersSignaturesRequest } from '@/interfaces/recovery/request/IGenerateServersSignaturesRequest.interface';
+import { IRecoverAccountRequest } from '@/interfaces/recovery/request/IRecoverAccountRequest.interface';
+import { IConfigureAccountRecoveryResponse } from '@/interfaces/recovery/response/IConfigureAccountRecoveryResponse.interface';
+import { IGenerateRecoveryChallengeResponse } from '@/interfaces/recovery/response/IGenerateRecoveryChallengeResponse.interface';
+import { IGenerateRecoveryTokenResponse } from '@/interfaces/recovery/response/IGenerateRecoveryTokenResponse.interface';
+import { IVerifyExternalAuthCodesResponse } from '@/interfaces/recovery/response/IVerifyExternalAuthCodesResponse.interface';
+import { IApiService } from '@/interfaces/services/IApiService';
+import { IRecoveryService } from '@/interfaces/services/IRecoveryService';
+import { IStellarXdrResponse } from '@/interfaces/stellar/IStellarXdrResponse';
+import { IBaseApiResponse } from '@/types/api.types';
+
+class RecoveryService implements IRecoveryService {
+	api: IApiService<ApiRequestConfig>;
+	constructor(api: IApiService<ApiRequestConfig>) {
+		this.api = api;
+	}
+
+	async getAuthChallenges() {
+		return await this.api.get<
+			IBaseApiResponse<IGenerateRecoveryChallengeResponse>
+		>('/recovery/auth');
+	}
+
+	async generateRecoveryTokens({
+		signedChallenges,
+	}: IGenerateRecoveryTokenRequest) {
+		return await this.api.post<
+			IBaseApiResponse<IGenerateRecoveryTokenResponse>
+		>('/recovery/auth', { signedChallenges });
+	}
+
+	async configureRecovery({
+		deviceKey,
+		tokens,
+	}: IConfigureAccountRecoveryRequest) {
+		return await this.api.post<
+			IBaseApiResponse<IConfigureAccountRecoveryResponse>
+		>(
+			'/recovery/configuration',
+			{ deviceKey },
+			{
+				headers: {
+					'Content-Type': 'application/json',
+					...formatTokenHeaders(tokens),
+				},
+			},
+		);
+	}
+
+	async saveSigner({ signers }: ICreateSignerRequest) {
+		await this.api.post('/recovery/signer', { signers });
+	}
+
+	async sendVerificationCodes() {
+		await this.api.get('/recovery/external-auth/verification');
+	}
+
+	async authenticateWithVerificationCode({
+		codes,
+	}: IAuthenticateWithVerificationCodeRequest) {
+		return await this.api.post<
+			IBaseApiResponse<IVerifyExternalAuthCodesResponse>
+		>('/recovery/external-auth/authentication', { codes });
+	}
+
+	async recoverAccount({ newDeviceKey }: IRecoverAccountRequest) {
+		return await this.api.post<IBaseApiResponse<IStellarXdrResponse>>(
+			'/recovery',
+			{ newDeviceKey },
+		);
+	}
+
+	async generateServersSignatures({
+		externalAuthTokens,
+		transaction,
+	}: IGenerateServersSignaturesRequest) {
+		return await this.api.post<IBaseApiResponse<IStellarXdrResponse>>(
+			'/recovery/signature',
+			{ transaction },
+			{
+				headers: {
+					'Content-Type': 'application/json',
+					...formatTokenHeaders(externalAuthTokens),
+				},
+			},
+		);
+	}
+}
+export const recoveryService = new RecoveryService(apiService);

--- a/src/types/enum/go-to-back-button-type.enum.ts
+++ b/src/types/enum/go-to-back-button-type.enum.ts
@@ -1,0 +1,4 @@
+export enum GoToBackButtonType {
+	BACK = 'back',
+	DISMISS = 'dismiss',
+}

--- a/src/validation/schema/recover-account.schema.ts
+++ b/src/validation/schema/recover-account.schema.ts
@@ -1,0 +1,12 @@
+import * as Yup from 'yup';
+
+import { ERROR_MESSAGES } from '@/errors/messages/error.messages';
+
+export const recoverAccountSchema = Yup.object().shape({
+	planetPayRecoveryCode: Yup.string()
+		.required(ERROR_MESSAGES.RECOVERY_CODE_REQUIRED_ERROR_MESSAGE)
+		.max(5, ERROR_MESSAGES.RECOVERY_CODE_MAX_LENGTH_ERROR_MESSAGE),
+	biggerRecoveryCode: Yup.string()
+		.required(ERROR_MESSAGES.RECOVERY_CODE_REQUIRED_ERROR_MESSAGE)
+		.max(5, ERROR_MESSAGES.RECOVERY_CODE_MAX_LENGTH_ERROR_MESSAGE),
+});

--- a/tests/__files/mocks.ts
+++ b/tests/__files/mocks.ts
@@ -1,0 +1,98 @@
+export const mockSignInResponse = {
+	data: {
+		type: 'authentication',
+		attributes: {
+			accessToken:
+				'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InhZSVoxVVlXRzBmTno5YVFmcTQzZyJ9.eyJpc3MiOiJodHRwczovL2Rldi00ZTM2ZHpiNmFqeDd1d3Y4LnVzLmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHw2N2JmN2VkN2YxM2RhOGJhYzRkYTNkMTMiLCJhdWQiOlsiaHR0cHM6Ly9yZWdlbi14LmRldi5jb20iLCJodHRwczovL2Rldi00ZTM2ZHpiNmFqeDd1d3Y4LnVzLmF1dGgwLmNvbS91c2VyaW5mbyJdLCJpYXQiOjE3NDA3Njk1MjQsImV4cCI6MTc0MDc2OTU4NCwic2NvcGUiOiJvcGVuaWQgcHJvZmlsZSBlbWFpbCB1cGRhdGU6dXNlcnMgcmVhZDp1c2VycyBvZmZsaW5lX2FjY2VzcyIsImd0eSI6InBhc3N3b3JkIiwiYXpwIjoienhuS0tIMFgwaFhkSlBEQ3NDWWhQMUVxbHdMcDhLbnkifQ.Zd1ZmoMrxugLmhVq8NPXT-Wm6kUwmQYdQpmnST3Up6uIVn4ATzDuQ4sCC6yczBKedfdm5KAZ2kYNcxlkbEiiC3tLPO_9HZWz3knElv7jM5XmtDND8MZxS_HdTjMH3RAG63JhYv3MOlEmkoBViONJoE-Pn7a4xUROgQ8b8x9H3TCy5kzCwFbjcjeVcztCEEIkdSNxuxGFwL-MRCshd2g3xJdLqS-sOsJzUZVE2YKjTaohbMh9JO4f8hcN6TTOIAiZdFZvDFzBXLhT0ZKlXToPj6looLycuxpju_8vrnGlGDz6mVOKBkq-XlWGwVJmUTVaJEfUiBKoxO3_uhyfTtyWKA',
+			refreshToken: 'QsV6Uk63eoBbRxTIt6yaNvhxrVLIiJY1ilT3FEe0Tb7gG',
+		},
+	},
+	links: {
+		self: 'http://localhost:5000/api/v1/auth/sign-in',
+	},
+};
+
+export const mockGetMeResponse = {
+	data: {
+		type: 'user',
+		attributes: {
+			username: 'test@example.com',
+			externalId: '1234567890',
+			uuid: '1234567890',
+			roles: ['user'],
+			name: 'Test User',
+			surname: 'Test User',
+			createdAt: '2021-01-01',
+			updatedAt: '2021-01-01',
+		},
+	},
+	links: {
+		self: 'http://localhost:5000/api/v1/users/1',
+	},
+};
+
+export const mockCreateWalletResponse = {
+	data: {
+		type: 'xdr',
+		attributes: {
+			xdr: 'AAAAAgAAAACtO4XLhxImozBDoTidJKBECVKijNEvpxlfjJHzGql/sAAABkAAFm14AAAACwAAAAEAAAAAAAAAAAAAAABn0H5wAAAAAAAAAAQAAAABAAAAAK07hcuHEiajMEOhOJ0koEQJUqKM0S+nGV+MkfMaqX+wAAAAEAAAAACUPerht88sgTbsxRHnwsesEnhb7yeh44ng/p2udssHwgAAAAEAAAAArTuFy4cSJqMwQ6E4nSSgRAlSoozRL6cZX4yR8xqpf7AAAAAAAAAAAJQ96uG3zyyBNuzFEefCx6wSeFvvJ6HjieD+na52ywfCAAAAAAL68IAAAAABAAAAAJQ96uG3zyyBNuzFEefCx6wSeFvvJ6HjieD+na52ywfCAAAABgAAAAFVU0RDAAAAACzBL+oSPrC5ICojTh8TqhPOYTUsqKwctXfdXRBSyExDf/////////8AAAABAAAAAJQ96uG3zyyBNuzFEefCx6wSeFvvJ6HjieD+na52ywfCAAAAEQAAAAAAAAACGql/sAAAAEAWIAeHmUZjxbtaCYwi86apg17VA0J5Uzj8B1MgXkV2HMd2wJMk1Cj6/fzVHj9/ERZ6+H6O5Y8RVf7FnRzKtiwKdssHwgAAAEBtflwjY543x3tp4OXKugmUp7m1wmKkpCCoE95GUXnmnspqxapHpZWmI0/kUdXqicU77NZi1EEuGXODbvEyIRQP',
+		},
+	},
+	links: {
+		self: 'http://localhost:5001/api/v1/user/create-wallet',
+	},
+};
+
+export const mockSubmitXdrResponse = {
+	data: {
+		type: 'submission',
+		attributes: {
+			hash: '1234567890',
+			successful: true,
+		},
+	},
+	links: {
+		self: 'http://localhost:5001/api/v1/submission',
+	},
+};
+export const mockAddWalletToUserResponse = {
+	data: {
+		type: 'user',
+		attributes: {
+			...mockGetMeResponse.data.attributes,
+			wallet: 'GCDMWZ3ZVUT6BV2KDODWPLFITF2OV2LUZVRZRFIGTWSSOA2KPXTRR6BB',
+		},
+	},
+	links: {
+		self: 'http://localhost:5001/api/v1/user',
+	},
+};
+
+export const mockAuthenticateWithVerificationCodeResponse = {
+	data: {
+		type: 'authentication',
+		attributes: {
+			externalAuthTokens: {
+				'local.recovery.io': 'token',
+				'recovery-local.systems': 'token',
+			},
+		},
+	},
+	links: {
+		self: 'http://localhost:5001/api/v1/auth/authenticate-with-verification-code',
+	},
+};
+
+export const mockRecoverAccountResponse = {
+	data: {
+		type: 'xdr',
+		attributes: {
+			xdr: 'AAAAAgAAAACtO4XLhxImozBDoTidJKBECVKijNEvpxlfjJHzGql/sAAABkAAFm14AAAACwAAAAEAAAAAAAAAAAAAAABn0H5wAAAAAAAAAAQAAAABAAAAAK07hcuHEiajMEOhOJ0koEQJUqKM0S+nGV+MkfMaqX+wAAAAEAAAAACUPerht88sgTbsxRHnwsesEnhb7yeh44ng/p2udssHwgAAAAEAAAAArTuFy4cSJqMwQ6E4nSSgRAlSoozRL6cZX4yR8xqpf7AAAAAAAAAAAJQ96uG3zyyBNuzFEefCx6wSeFvvJ6HjieD+na52ywfCAAAAAAL68IAAAAABAAAAAJQ96uG3zyyBNuzFEefCx6wSeFvvJ6HjieD+na52ywfCAAAABgAAAAFVU0RDAAAAACzBL+oSPrC5ICojTh8TqhPOYTUsqKwctXfdXRBSyExDf/////////8AAAABAAAAAJQ96uG3zyyBNuzFEefCx6wSeFvvJ6HjieD+na52ywfCAAAAEQAAAAAAAAACGql/sAAAAEAWIAeHmUZjxbtaCYwi86apg17VA0J5Uzj8B1MgXkV2HMd2wJMk1Cj6/fzVHj9/ERZ6+H6O5Y8RVf7FnRzKtiwKdssHwgAAAEBtflwjY543x3tp4OXKugmUp7m1wmKkpCCoE95GUXnmnspqxapHpZWmI0/kUdXqicU77NZi1EEuGXODbvEyIRQP',
+		},
+	},
+	links: {
+		self: 'http://localhost:5001/api/v1/recovery',
+	},
+};
+
+export const mockGenerateServersSignaturesResponse = mockRecoverAccountResponse;

--- a/tests/unit-test/ConfirmPasswordScreen.test.tsx
+++ b/tests/unit-test/ConfirmPasswordScreen.test.tsx
@@ -59,7 +59,7 @@ describe('ConfirmPasswordScreen', () => {
 		const codeInput = await findByPlaceholderText('Enter the code');
 		const submitButton = await findByText('Change Password');
 
-		await act(() => {
+		await act(async () => {
 			fireEvent.changeText(passwordInput, 'Newpassword123.');
 			fireEvent.changeText(codeInput, '123456');
 			fireEvent.press(submitButton);

--- a/tests/unit-test/ConfirmUserScreen.test.tsx
+++ b/tests/unit-test/ConfirmUserScreen.test.tsx
@@ -50,7 +50,7 @@ describe('ConfirmUserScreen', () => {
 		const codeInput = await findByPlaceholderText('Enter your code');
 		const confirmButton = await findByText('Confirm');
 
-		await act(() => {
+		await act(async () => {
 			fireEvent.changeText(codeInput, '123456');
 			fireEvent.press(confirmButton);
 		});

--- a/tests/unit-test/ForgotPasswordScreen.test.tsx
+++ b/tests/unit-test/ForgotPasswordScreen.test.tsx
@@ -38,7 +38,7 @@ describe('ForgotPasswordScreen', () => {
 		const usernameInput = await findByTestId('forgotPasswordUsernameInput');
 		const sendButton = await findByText('Send Code');
 
-		await act(() => {
+		await act(async () => {
 			fireEvent.changeText(usernameInput, 'test@example.com');
 			fireEvent.press(sendButton);
 		});

--- a/tests/unit-test/LoginScreen.test.tsx
+++ b/tests/unit-test/LoginScreen.test.tsx
@@ -1,35 +1,72 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render } from '@testing-library/react-native';
 import { useRouter } from 'expo-router';
 import { act } from 'react';
 
+import * as handleConfigureRecovery from '../../utils/recovery/handleConfigureRecovery';
+import * as signTransaction from '../../utils/stellar/signTransaction';
+import * as getSecureStorageItem from '../../utils/storage/getSecureStorageItem';
+import {
+	mockAddWalletToUserResponse,
+	mockCreateWalletResponse,
+	mockGetMeResponse,
+	mockSignInResponse,
+	mockSubmitXdrResponse,
+} from '../__files/mocks';
+
 import LoginScreen from '@/app/(auth)/login';
 import { NavigationRoutes } from '@/constants/navigation.routes.enum';
-import { useAuth } from '@/hooks/useAuthApi';
+import { authService } from '@/services/auth/auth.service';
+import { recoveryService } from '@/services/recovery/recovery.service';
+import tokenStorage from '@/services/storage/token-storage';
+import { submissionService } from '@/services/submission/submission.service';
+import { userService } from '@/services/user/user.service';
 
 jest.mock('expo-router', () => ({
 	useRouter: jest.fn(),
 }));
 
-jest.mock('@/hooks/useAuthApi', () => ({
-	useAuth: jest.fn(),
-}));
+const queryClient = new QueryClient();
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+	<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
 
-describe('LoginScreen', () => {
+describe.skip('LoginScreen', () => {
 	const mockPush = jest.fn();
-	const mockSignInMutation = {
-		mutate: jest.fn(),
-	};
+	const mockReplace = jest.fn();
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		(useRouter as jest.Mock).mockReturnValue({ push: mockPush });
-		(useAuth as jest.Mock).mockReturnValue({
-			signInMutation: mockSignInMutation,
-			isLoading: {
-				signIn: false,
-				firstLogin: false,
-			},
+		(useRouter as jest.Mock).mockReturnValue({
+			push: mockPush,
+			replace: mockReplace,
 		});
+		jest.spyOn(authService, 'signIn').mockResolvedValue(mockSignInResponse);
+
+		jest.spyOn(authService, 'getMe').mockResolvedValue(mockGetMeResponse);
+
+		jest
+			.spyOn(userService, 'createWallet')
+			.mockResolvedValue(mockCreateWalletResponse);
+
+		jest.spyOn(signTransaction, 'signTransaction').mockReturnValue('signedXdr');
+
+		jest
+			.spyOn(submissionService, 'submitXdr')
+			.mockResolvedValue(mockSubmitXdrResponse);
+
+		jest
+			.spyOn(userService, 'addWalletToUser')
+			.mockResolvedValue(mockAddWalletToUserResponse);
+
+		jest
+			.spyOn(handleConfigureRecovery, 'handleConfigureRecovery')
+			.mockImplementationOnce(() => Promise.resolve());
+
+		jest.spyOn(tokenStorage, 'setAccessToken').mockResolvedValue();
+		jest.spyOn(tokenStorage, 'setRefreshToken').mockResolvedValue();
+
+		jest.spyOn(recoveryService, 'sendVerificationCodes').mockResolvedValue();
 	});
 
 	test('Should render login screen correctly', async () => {
@@ -55,7 +92,7 @@ describe('LoginScreen', () => {
 
 		const registerButton = await findByTestId('goToRegisterButton');
 
-		await act(() => {
+		await act(async () => {
 			fireEvent.press(registerButton);
 		});
 
@@ -67,58 +104,44 @@ describe('LoginScreen', () => {
 
 		const forgotPasswordButton = await findByTestId('goToForgotPasswordButton');
 
-		await act(() => {
+		await act(async () => {
 			fireEvent.press(forgotPasswordButton);
 		});
 
 		expect(mockPush).toHaveBeenCalledWith(NavigationRoutes.FORGOT_PASSWORD);
 	});
 
-	test('Should call sign in mutation when form is submitted', async () => {
-		const { findByTestId } = render(<LoginScreen />);
+	test('Should redirect to recovery screen when user deviceKey is missing after login', async () => {
+		const { findByTestId } = render(<LoginScreen />, { wrapper });
 
 		const usernameInput = await findByTestId('loginUsernameInput');
 		const passwordInput = await findByTestId('loginPasswordInput');
 		const loginButton = await findByTestId('loginSubmitButton');
 
-		await act(() => {
+		await act(async () => {
 			fireEvent.changeText(usernameInput, 'test@example.com');
 			fireEvent.changeText(passwordInput, 'Password123.');
 			fireEvent.press(loginButton);
 		});
 
-		expect(mockSignInMutation.mutate).toHaveBeenCalledWith({
-			username: 'test@example.com',
-			password: 'Password123.',
-		});
+		expect(mockReplace).toHaveBeenCalledWith(NavigationRoutes.RECOVERY);
 	});
 
-	test('Should show loading state during sign in', async () => {
-		(useAuth as jest.Mock).mockReturnValue({
-			signInMutation: mockSignInMutation,
-			isLoading: {
-				signIn: true,
-				firstLogin: false,
-			},
-		});
+	test('Should redirect to home screen after a successful first login', async () => {
+		jest.spyOn(getSecureStorageItem, 'default').mockResolvedValue('secretKey');
 
-		const { findByTestId } = render(<LoginScreen />);
+		const { findByTestId } = render(<LoginScreen />, { wrapper });
+
+		const usernameInput = await findByTestId('loginUsernameInput');
+		const passwordInput = await findByTestId('loginPasswordInput');
 		const loginButton = await findByTestId('loginSubmitButton');
-		expect(loginButton.props.accessibilityState.disabled).toBeTruthy();
-	});
 
-	test('Should show first login modal when creating wallet', async () => {
-		(useAuth as jest.Mock).mockReturnValue({
-			signInMutation: mockSignInMutation,
-			isLoading: {
-				signIn: false,
-				firstLogin: true,
-			},
+		await act(async () => {
+			fireEvent.changeText(usernameInput, 'test@example.com');
+			fireEvent.changeText(passwordInput, 'Password123.');
+			fireEvent.press(loginButton);
 		});
 
-		const { findByTestId } = render(<LoginScreen />);
-		const firstLoginModal = await findByTestId('firstLoginModal');
-
-		expect(firstLoginModal).toBeTruthy();
+		expect(mockReplace).toHaveBeenCalledWith(NavigationRoutes.HOME);
 	});
 });

--- a/tests/unit-test/LoginScreen.test.tsx
+++ b/tests/unit-test/LoginScreen.test.tsx
@@ -71,7 +71,7 @@ describe('LoginScreen', () => {
 	});
 
 	test('Should render login screen correctly', async () => {
-		const { findByTestId } = render(<LoginScreen />);
+		const { findByTestId } = render(<LoginScreen />, { wrapper });
 
 		const screen = await findByTestId('loginScreen');
 		const usernameInput = await findByTestId('loginUsernameInput');
@@ -89,7 +89,7 @@ describe('LoginScreen', () => {
 	});
 
 	test('Should navigate to register screen when register button is pressed', async () => {
-		const { findByTestId } = render(<LoginScreen />);
+		const { findByTestId } = render(<LoginScreen />, { wrapper });
 
 		const registerButton = await findByTestId('goToRegisterButton');
 
@@ -101,7 +101,7 @@ describe('LoginScreen', () => {
 	});
 
 	test('Should navigate to forgot password screen when forgot password button is pressed', async () => {
-		const { findByTestId } = render(<LoginScreen />);
+		const { findByTestId } = render(<LoginScreen />, { wrapper });
 
 		const forgotPasswordButton = await findByTestId('goToForgotPasswordButton');
 

--- a/tests/unit-test/LoginScreen.test.tsx
+++ b/tests/unit-test/LoginScreen.test.tsx
@@ -30,8 +30,9 @@ const queryClient = new QueryClient();
 const wrapper = ({ children }: { children: React.ReactNode }) => (
 	<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
+process.env.EXPO_PUBLIC_API_URL = 'http://localhost:5001';
 
-describe.skip('LoginScreen', () => {
+describe('LoginScreen', () => {
 	const mockPush = jest.fn();
 	const mockReplace = jest.fn();
 

--- a/tests/unit-test/RecoveryScreen.test.tsx
+++ b/tests/unit-test/RecoveryScreen.test.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render } from '@testing-library/react-native';
+import { useRouter } from 'expo-router';
+import { act } from 'react';
+
+import * as handleStoreDeviceSecretKey from '../../utils/handleDeviceSecretKey';
+import {
+	mockAuthenticateWithVerificationCodeResponse,
+	mockGenerateServersSignaturesResponse,
+	mockRecoverAccountResponse,
+	mockSubmitXdrResponse,
+} from '../__files/mocks';
+
+import RecoverAccountScreen from '@/app/(recovery)/recover-account';
+import { NavigationRoutes } from '@/constants/navigation.routes.enum';
+import { useAuthContext } from '@/context/auth.context';
+import { recoveryService } from '@/services/recovery/recovery.service';
+import { submissionService } from '@/services/submission/submission.service';
+
+jest.mock('expo-router', () => ({
+	useRouter: jest.fn(),
+}));
+
+jest.mock('@/context/auth.context', () => ({
+	useAuthContext: jest.fn(),
+}));
+
+const queryClient = new QueryClient();
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+	<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe('RecoverAccountScreen', () => {
+	const mockPush = jest.fn();
+	const mockReplace = jest.fn();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		(useRouter as jest.Mock).mockReturnValue({
+			push: mockPush,
+			replace: mockReplace,
+		});
+		(useAuthContext as jest.Mock).mockReturnValue({
+			user: {
+				deviceSecretKey: 'secretKey',
+			},
+			setIsAuthenticated: jest.fn(),
+		});
+
+		jest
+			.spyOn(recoveryService, 'authenticateWithVerificationCode')
+			.mockResolvedValue(mockAuthenticateWithVerificationCodeResponse);
+
+		jest
+			.spyOn(recoveryService, 'recoverAccount')
+			.mockResolvedValue(mockRecoverAccountResponse);
+
+		jest
+			.spyOn(recoveryService, 'generateServersSignatures')
+			.mockResolvedValue(mockGenerateServersSignaturesResponse);
+
+		jest
+			.spyOn(submissionService, 'submitXdr')
+			.mockResolvedValue(mockSubmitXdrResponse);
+
+		jest
+			.spyOn(handleStoreDeviceSecretKey, 'storeDeviceSecretKey')
+			.mockResolvedValue();
+	});
+
+	test('Should render Recovery screen correctly', async () => {
+		const { findByTestId } = render(<RecoverAccountScreen />, { wrapper });
+
+		const recoveryTitle = await findByTestId('recoverAccountScreenTitle');
+		const recoverAccountIndications = await findByTestId(
+			'recoverAccountIndications',
+		);
+		const planetPayRecoveryCodeInput = await findByTestId(
+			'planetPayRecoveryCodeInput',
+		);
+		const biggerRecoveryCodeInput = await findByTestId(
+			'biggerRecoveryCodeInput',
+		);
+		const recoverAccountButton = await findByTestId(
+			'recoverAccountSubmitButton',
+		);
+
+		expect(recoveryTitle).toBeTruthy();
+		expect(recoverAccountIndications).toBeTruthy();
+		expect(planetPayRecoveryCodeInput).toBeTruthy();
+		expect(biggerRecoveryCodeInput).toBeTruthy();
+		expect(recoverAccountButton).toBeTruthy();
+	});
+
+	test('Should display validation errors if no recovery code is provided', async () => {
+		const { findByTestId } = render(<RecoverAccountScreen />, { wrapper });
+
+		const recoverAccountButton = await findByTestId(
+			'recoverAccountSubmitButton',
+		);
+
+		await act(async () => {
+			fireEvent.press(recoverAccountButton);
+		});
+
+		const planetPayRecoveryCodeInputError = await findByTestId(
+			'planetPayRecoveryCodeInputError',
+		);
+		const biggerRecoveryCodeInputError = await findByTestId(
+			'biggerRecoveryCodeInputError',
+		);
+
+		expect(planetPayRecoveryCodeInputError).toBeTruthy();
+		expect(biggerRecoveryCodeInputError).toBeTruthy();
+	});
+
+	test('Should redirect to home screen after a successful recovery', async () => {
+		const { findByTestId } = render(<RecoverAccountScreen />, { wrapper });
+
+		const planetPayRecoveryCodeInput = await findByTestId(
+			'planetPayRecoveryCodeInput',
+		);
+		const biggerRecoveryCodeInput = await findByTestId(
+			'biggerRecoveryCodeInput',
+		);
+		const recoverAccountButton = await findByTestId(
+			'recoverAccountSubmitButton',
+		);
+
+		await act(async () => {
+			fireEvent.changeText(planetPayRecoveryCodeInput, '12345');
+			fireEvent.changeText(biggerRecoveryCodeInput, '54321');
+			fireEvent.press(recoverAccountButton);
+		});
+
+		expect(mockReplace).toHaveBeenCalledWith(NavigationRoutes.HOME);
+	});
+});

--- a/tests/unit-test/RegisterScreen.test.tsx
+++ b/tests/unit-test/RegisterScreen.test.tsx
@@ -50,7 +50,7 @@ describe('RegisterScreen', () => {
 		const biographyInput = await findByTestId('registerBiographyInput');
 		const submitButton = await findByTestId('registerSubmitButton');
 
-		await act(() => {
+		await act(async () => {
 			fireEvent.changeText(usernameInput, 'test@example.com');
 			fireEvent.changeText(passwordInput, 'Password.123');
 			fireEvent.changeText(nameInput, 'John');

--- a/utils/formatRecoveryCodesByDomain.ts
+++ b/utils/formatRecoveryCodesByDomain.ts
@@ -1,0 +1,9 @@
+import { accountRecoveryDomains } from '@/constants/account-recovery-domains';
+import { IRecoveryCodesFormFields } from '@/interfaces/recovery/request/IRecoveryCodesFormFields.interface';
+
+export const formatRecoveryCodesByDomain = (data: IRecoveryCodesFormFields) => {
+	return {
+		[accountRecoveryDomains.PLANET_PAY]: data.planetPayRecoveryCode,
+		[accountRecoveryDomains.BIGGER]: data.biggerRecoveryCode,
+	};
+};

--- a/utils/formatTokenHeaders.ts
+++ b/utils/formatTokenHeaders.ts
@@ -1,0 +1,12 @@
+import { IServerDomainKeyValueResponse } from '@/interfaces/recovery/IServerDomainKeyValueResponse.interface';
+
+export const formatTokenHeaders = (
+	externalAuthTokens: IServerDomainKeyValueResponse,
+) => {
+	return Object.fromEntries(
+		Object.entries(externalAuthTokens).map(([domain, token]) => [
+			`${domain}-recovery-token`,
+			token,
+		]),
+	);
+};

--- a/utils/handleDeviceSecretKey.ts
+++ b/utils/handleDeviceSecretKey.ts
@@ -7,19 +7,20 @@ import { ERROR_MESSAGES } from '@/errors/messages/error.messages';
 export const storeDeviceSecretKey = async (
 	accountEmail: string,
 	deviceSecretKey: string,
+	isMasterKey: boolean = true,
 ): Promise<void> => {
 	try {
-		const formattedEmail = formatEmailAsKey(accountEmail);
+		const formattedEmail = `${isMasterKey ? 'master' : 'device'}-${formatEmailAsKey(accountEmail)}`;
 		await setSecureStorageItem(formattedEmail, deviceSecretKey);
-	} catch (error) {
-		console.error(error);
+	} catch {
 		throw new Error(ERROR_MESSAGES.GEN_DEVICE_KEYPAIR);
 	}
 };
 
 export const getDeviceSecretKey = async (
 	accountEmail: string,
+	isMasterKey: boolean = true,
 ): Promise<string> => {
-	const formattedEmail = formatEmailAsKey(accountEmail);
+	const formattedEmail = `${isMasterKey ? 'master' : 'device'}-${formatEmailAsKey(accountEmail)}`;
 	return await getSecureStorageItem(formattedEmail);
 };

--- a/utils/recovery/handleConfigureRecovery.ts
+++ b/utils/recovery/handleConfigureRecovery.ts
@@ -1,0 +1,45 @@
+import { Keypair } from '@stellar/stellar-sdk';
+
+import { signTransaction } from '../stellar/signTransaction';
+import { signChallenges } from './signChallenges';
+
+import { ERROR_MESSAGES } from '@/errors/messages/error.messages';
+import { recoveryService } from '@/services/recovery/recovery.service';
+import { submissionService } from '@/services/submission/submission.service';
+
+export const handleConfigureRecovery = async (
+	deviceKeypair: Keypair,
+	masterKeypair: Keypair,
+) => {
+	try {
+		const {
+			data: {
+				attributes: { challenges },
+			},
+		} = await recoveryService.getAuthChallenges();
+
+		const signedChallenges = signChallenges(masterKeypair.secret(), challenges);
+
+		const {
+			data: {
+				attributes: { tokens },
+			},
+		} = await recoveryService.generateRecoveryTokens({
+			signedChallenges,
+		});
+		const {
+			data: {
+				attributes: { xdr, signers },
+			},
+		} = await recoveryService.configureRecovery({
+			deviceKey: deviceKeypair.publicKey(),
+			tokens,
+		});
+
+		const signedTransaction = signTransaction(xdr, masterKeypair.secret());
+		await submissionService.submitXdr(signedTransaction);
+		await recoveryService.saveSigner({ signers });
+	} catch {
+		throw new Error(ERROR_MESSAGES.GENERATING_RECOVERY_ACCOUNTS);
+	}
+};

--- a/utils/recovery/signChallenges.ts
+++ b/utils/recovery/signChallenges.ts
@@ -1,0 +1,21 @@
+import { signTransaction } from '../stellar/signTransaction';
+
+import { ERROR_MESSAGES } from '@/errors/messages/error.messages';
+import { IServerDomainKeyValueResponse } from '@/interfaces/recovery/IServerDomainKeyValueResponse.interface';
+
+export const signChallenges = (
+	secretKey: string,
+	challenges: IServerDomainKeyValueResponse,
+): IServerDomainKeyValueResponse => {
+	try {
+		return Object.fromEntries(
+			Object.entries(challenges).map(([key, xdr]) => [
+				key,
+				signTransaction(xdr, secretKey),
+			]),
+		);
+	} catch (error) {
+		console.error('Error signing challenges:', error);
+		throw new Error(ERROR_MESSAGES.SIGNING_CHALLENGES);
+	}
+};

--- a/utils/stellar/signTransaction.ts
+++ b/utils/stellar/signTransaction.ts
@@ -1,0 +1,8 @@
+import { Keypair, Networks, TransactionBuilder } from '@stellar/stellar-sdk';
+
+export const signTransaction = (xdr: string, secretKey: string) => {
+	const keypair = Keypair.fromSecret(secretKey);
+	const transaction = TransactionBuilder.fromXDR(xdr, Networks.TESTNET);
+	transaction.sign(keypair);
+	return transaction.toXDR();
+};

--- a/utils/stellar/signTransaction.ts
+++ b/utils/stellar/signTransaction.ts
@@ -1,8 +1,11 @@
 import { Keypair, Networks, TransactionBuilder } from '@stellar/stellar-sdk';
 
+const stellarNetwork =
+	process.env.EXPO_PUBLIC_STELLAR_NETWORK ?? Networks.TESTNET;
+
 export const signTransaction = (xdr: string, secretKey: string) => {
 	const keypair = Keypair.fromSecret(secretKey);
-	const transaction = TransactionBuilder.fromXDR(xdr, Networks.TESTNET);
+	const transaction = TransactionBuilder.fromXDR(xdr, stellarNetwork);
 	transaction.sign(keypair);
 	return transaction.toXDR();
 };

--- a/utils/storage/getSecureStorageItem.ts
+++ b/utils/storage/getSecureStorageItem.ts
@@ -1,5 +1,7 @@
 import * as SecureStore from 'expo-secure-store';
 
+import { ERROR_MESSAGES } from '@/errors/messages/error.messages';
+
 const getSecureStorageItem = async (keyIdentifier: string): Promise<string> => {
 	try {
 		const keychainService = `secretKey-${keyIdentifier}`;
@@ -7,16 +9,9 @@ const getSecureStorageItem = async (keyIdentifier: string): Promise<string> => {
 			keychainService,
 		});
 
-		if (!secretKey) {
-			throw new Error(
-				'Error getting secret key: No credentials found for identifier',
-			);
-		}
-
-		return secretKey;
-	} catch (error) {
-		const err = error as Error;
-		throw new Error(err.message);
+		return secretKey ?? '';
+	} catch {
+		throw new Error(ERROR_MESSAGES.GETTING_SECRET_KEY);
 	}
 };
 


### PR DESCRIPTION
# Summary
This PR adds the logic and UI for Stellar account recovery, allowing the device to store an account that **signs** on behalf of the user. If the account is **not found** during login, the user is prompted to enter verification codes sent via email to assign a new **signing device** key to their account

# Details
* Create Recovery request and response interfaces
* Create RecoveryService with all the methods needed to configure the recovery and to recover an account
* Create SecureStorage utils to save and read the user device key
* Update signIn logic to add the account recovery configuration
* Create RecoverAccount Screen with a form to send the recovery codes


# Evidence
![image](https://github.com/user-attachments/assets/029c7ce2-884f-40fc-b39f-679f6454470d)

# Tickets
[Ticket](https://3.basecamp.com/5876231/buckets/41087924/card_tables/cards/8371188215)